### PR TITLE
Add license section to main docs page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,6 +24,14 @@ simulations.
    AITraining/index
 
 
+License
+=======
+
+E3SM model output data released by the E3SM project, including E3SM datasets
+submitted to CMIP/ESGF, are distributed under the `Creative Commons Attribution
+4.0 International license, CC BY 4.0 <https://creativecommons.org/licenses/by/4.0/>`_.
+
+
 
 .. Indices and tables
 .. ==================


### PR DESCRIPTION
Adds a License section (CC BY 4.0) to the bottom of the main docs page.