### PR TITLE
Add remaining ESGF links from e3sm.org

### DIFF
--- a/docs/source/v1/BGC/simulation_data/index.rst
+++ b/docs/source/v1/BGC/simulation_data/index.rst
@@ -56,6 +56,22 @@ Some original run scripts (the scripts that were originally used to create the s
 
    zstash extract --hpss=/home/projects/e3sm/www/BGC/E3SMv1/<simulation_name>/ case_scripts/run_script_provenance/*
 
+In the table below, there are 6 main categories of data:
+
+* `CTC CMIP piControl <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-1-1&experiment_id=piControl>`_
+* `CTC C4MIP hist-bgc <https://esgf-node.llnl.gov/search/cmip6/?activity_id=C4MIP&source_id=E3SM-1-1&experiment_id=hist-bgc>`_
+* `CTC C4MIP ssp585-bgc <https://esgf-node.llnl.gov/search/cmip6/?activity_id=C4MIP&source_id=E3SM-1-1&experiment_id=ssp585-bgc>`_
+* `ECA CMIP piControl <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-1-1-ECA&experiment_id=piControl>`_
+* `ECA C4MIP hist-bgc <https://esgf-node.llnl.gov/search/cmip6/?activity_id=C4MIP&source_id=E3SM-1-1-ECA&experiment_id=hist-bgc>`_
+* `ECA C4MIP ssp585-bgc <https://esgf-node.llnl.gov/search/cmip6/?activity_id=C4MIP&source_id=E3SM-1-1-ECA&experiment_id=ssp585-bgc>`_
+
+Other relevant ESGF links include:
+* `CTC CMIP historical <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-1-1&experiment_id=historical>`_
+* `CTC ScenarioMIP ssp585 <https://esgf-node.llnl.gov/search/cmip6/?activity_id=ScenarioMIP&source_id=E3SM-1-1&experiment_id=ssp585>`_
+* `CTC ScenarioMIP ssp245 <https://esgf-node.llnl.gov/search/cmip6/?activity_id=ScenarioMIP&source_id=E3SM-1-1&experiment_id=ssp245>`_
+* `CTC DAMIP ​ssp245-covid <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-1-1&experiment_id=ssp245-covid>`_
+* `ECA CMIP historical <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-1-1-ECA&experiment_id=historical>`_
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/docs/source/v1/BGC/simulation_data/simulation_table.rst
+++ b/docs/source/v1/BGC/simulation_data/simulation_table.rst
@@ -18,7 +18,7 @@ v1 BGC simulation table
      - 
    * - E3SM_1_1_piControl
      - 23
-     - 
+     - `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-1-1&experiment_id=piControl>`_
      - (symlink) /home/projects/e3sm/www/BGC/E3SMv1/E3SM_1_1_piControl
      - `HPSS URL <https://portal.nersc.gov/archive/home/projects/e3sm/www/BGC/E3SMv1/E3SM_1_1_piControl>`_
    * - E3SM_1_1_piControl-ext85yr
@@ -93,7 +93,7 @@ v1 BGC simulation table
      - 
    * - E3SM_1_1_ECA_piControl
      - 22
-     - 
+     - `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-1-1-ECA&experiment_id=piControl>`_
      - (symlink) /home/projects/e3sm/www/BGC/E3SMv1/E3SM_1_1_ECA_piControl
      - `HPSS URL <https://portal.nersc.gov/archive/home/projects/e3sm/www/BGC/E3SMv1/E3SM_1_1_ECA_piControl>`_
    * - E3SM_1_1_ECA_piControl-ext85yr

--- a/docs/source/v1/WaterCycle/simulation_data/simulation_table.rst
+++ b/docs/source/v1/WaterCycle/simulation_data/simulation_table.rst
@@ -16,11 +16,11 @@ v1 WaterCycle simulation table
      - 
    * - 20180129.DECKv1b_piControl.ne30_oEC.edison
      - 40
-     - `CMIP <https://esgf-node.ornl.gov/search?project=CMIP6&activeFacets=%7B%22institution_id%22%3A%22E3SM-Project%22%2C%22source_id%22%3A%22E3SM-1-0%22%2C%22experiment_id%22%3A%22piControl%22%2C%22variant_label%22%3A%22r1i1p1f1%22%7D>`_
+     - `CMIP <https://esgf-node.ornl.gov/search?project=CMIP6&activeFacets=%7B%22institution_id%22%3A%22E3SM-Project%22%2C%22source_id%22%3A%22E3SM-1-0%22%2C%22experiment_id%22%3A%22piControl%22%2C%22variant_label%22%3A%22r1i1p1f1%22%7D>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-1-0&experiment_id=piControl>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv1/LR/20180129.DECKv1b_piControl.ne30_oEC.edison
    * - 20180215.DECKv1b_abrupt4xCO2.ne30_oEC.edison
      - 12
-     - `CMIP <https://esgf-node.ornl.gov/search?project=CMIP6&activeFacets=%7B%22institution_id%22%3A%22E3SM-Project%22%2C%22source_id%22%3A%22E3SM-1-0%22%2C%22experiment_id%22%3A%22abrupt-4xCO2%22%2C%22variant_label%22%3A%22r1i1p1f1%22%7D>`_
+     - `CMIP <https://esgf-node.ornl.gov/search?project=CMIP6&activeFacets=%7B%22institution_id%22%3A%22E3SM-Project%22%2C%22source_id%22%3A%22E3SM-1-0%22%2C%22experiment_id%22%3A%22abrupt-4xCO2%22%2C%22variant_label%22%3A%22r1i1p1f1%22%7D>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-1-0&experiment_id=abrupt-4xCO2>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv1/LR/20180215.DECKv1b_abrupt4xCO2.ne30_oEC.edison
    * - 20190722.DECKv1b_abrupt4xCO2.ne30_oEC3.compy
      - 14
@@ -28,9 +28,9 @@ v1 WaterCycle simulation table
      - /home/projects/e3sm/www/WaterCycle/E3SMv1/LR/20190722.DECKv1b_abrupt4xCO2.ne30_oEC3.compy
    * - 20180215.DECKv1b_1pctCO2.ne30_oEC.edison
      - 12
-     - 
+     - `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-1-0&experiment_id=1pctCO2_>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv1/LR/20180215.DECKv1b_1pctCO2.ne30_oEC.edison
-   * - **LR > Historical**
+   * - **LR > Historical** (`Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-1-0&experiment_id=historical>`_)
      - 
      - 
      - 
@@ -54,7 +54,7 @@ v1 WaterCycle simulation table
      - 13
      - `CMIP <https://esgf-node.ornl.gov/search?project=CMIP6&activeFacets=%7B%22institution_id%22%3A%22E3SM-Project%22%2C%22source_id%22%3A%22E3SM-1-0%22%2C%22experiment_id%22%3A%22historical%22%2C%22variant_label%22%3A%22r5i1p1f1%22%7D>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv1/LR/20180307.DECKv1b_H5.ne30_oEC.edison
-   * - **LR > AMIP**
+   * - **LR > AMIP** (`Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-1-0&experiment_id=amip>`_)
      - 
      - 
      - 

--- a/docs/source/v2/WaterCycle/simulation_data/simulation_table.rst
+++ b/docs/source/v2/WaterCycle/simulation_data/simulation_table.rst
@@ -16,7 +16,7 @@ v2 WaterCycle simulation table
      - 
    * - v2.LR.piControl
      - 39
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piControl&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piControl&ensemble_member=ens1>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piControl&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piControl&ensemble_member=ens1>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-2-0&experiment_id=piControl>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.piControl
    * - v2.LR.piControl_land
      - 
@@ -24,17 +24,17 @@ v2 WaterCycle simulation table
      - 
    * - v2.LR.abrupt-4xCO2_0101
      - 12
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=abrupt-4xCO2&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=abrupt-4xCO2&ensemble_member=ens1>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=abrupt-4xCO2&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=abrupt-4xCO2&ensemble_member=ens1>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-2-0&experiment_id=abrupt-4xCO2>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.abrupt-4xCO2_0101
    * - v2.LR.abrupt-4xCO2_0301
      - 13
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=abrupt-4xCO2&variant_label=r2i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=abrupt-4xCO2&ensemble_member=ens2>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=abrupt-4xCO2&variant_label=r2i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=abrupt-4xCO2&ensemble_member=ens2>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-2-0&experiment_id=abrupt-4xCO2>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.abrupt-4xCO2_0301
    * - v2.LR.1pctCO2_0101
      - 12
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=1pctCO2&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=1pctCO2&ensemble_member=ens1>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=1pctCO2&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=1pctCO2&ensemble_member=ens1>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-2-0&experiment_id=1pctCO2>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.1pctCO2_0101
-   * - **LR > Historical**
+   * - **LR > Historical** (`Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-2-0&experiment_id=historical>`_)
      - 
      - 
      - 
@@ -224,65 +224,65 @@ v2 WaterCycle simulation table
      - 
    * - v2.LR.hist-GHG_0101
      - 13
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-GHG&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-GHG&ensemble_member=ens1>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-GHG&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-GHG&ensemble_member=ens1>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-2-0&experiment_id=hist-GHG>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.hist-GHG_0101
    * - v2.LR.hist-GHG_0151
      - 13
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-GHG&variant_label=r2i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-GHG&ensemble_member=ens2>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-GHG&variant_label=r2i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-GHG&ensemble_member=ens2>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-2-0&experiment_id=hist-GHG>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.hist-GHG_0151
    * - v2.LR.hist-GHG_0201
      - 13
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-GHG&variant_label=r3i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-GHG&ensemble_member=ens3>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-GHG&variant_label=r3i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-GHG&ensemble_member=ens3>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-2-0&experiment_id=hist-GHG>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.hist-GHG_0201
    * - v2.LR.hist-GHG_0251
      - 14
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-GHG&variant_label=r4i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-GHG&ensemble_member=ens4>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-GHG&variant_label=r4i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-GHG&ensemble_member=ens4>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-2-0&experiment_id=hist-GHG>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.hist-GHG_0251
    * - v2.LR.hist-GHG_0301
      - 13
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-GHG&variant_label=r5i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-GHG&ensemble_member=ens5>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-GHG&variant_label=r5i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-GHG&ensemble_member=ens5>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-2-0&experiment_id=hist-GHG>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.hist-GHG_0301
    * - v2.LR.hist-aer_0101
      - 13
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-aer&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-aer&ensemble_member=ens1>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-aer&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-aer&ensemble_member=ens1>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-2-0&experiment_id=hist-aer>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.hist-aer_0101
    * - v2.LR.hist-aer_0151
      - 13
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-aer&variant_label=r2i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-aer&ensemble_member=ens2>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-aer&variant_label=r2i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-aer&ensemble_member=ens2>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-2-0&experiment_id=hist-aer>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.hist-aer_0151
    * - v2.LR.hist-aer_0201
      - 13
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-aer&variant_label=r3i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-aer&ensemble_member=ens3>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-aer&variant_label=r3i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-aer&ensemble_member=ens3>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-2-0&experiment_id=hist-aer>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.hist-aer_0201
    * - v2.LR.hist-aer_0251
      - 14
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-aer&variant_label=r4i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-aer&ensemble_member=ens4>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-aer&variant_label=r4i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-aer&ensemble_member=ens4>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-2-0&experiment_id=hist-aer>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.hist-aer_0251
    * - v2.LR.hist-aer_0301
      - 14
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-aer&variant_label=r5i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-aer&ensemble_member=ens5>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-aer&variant_label=r5i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-aer&ensemble_member=ens5>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-2-0&experiment_id=hist-aer>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.hist-aer_0301
    * - v2.LR.hist-all-xGHG-xaer_0101
      - 13
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-nat&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-all-xGHG-xaer&ensemble_member=ens1>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-nat&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-all-xGHG-xaer&ensemble_member=ens1>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-2-0&experiment_id=hist-nat>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.hist-all-xGHG-xaer_0101
    * - v2.LR.hist-all-xGHG-xaer_0151
      - 13
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-nat&variant_label=r2i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-all-xGHG-xaer&ensemble_member=ens2>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-nat&variant_label=r2i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-all-xGHG-xaer&ensemble_member=ens2>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-2-0&experiment_id=hist-nat>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.hist-all-xGHG-xaer_0151
    * - v2.LR.hist-all-xGHG-xaer_0201
      - 13
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-nat&variant_label=r3i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-all-xGHG-xaer&ensemble_member=ens3>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-nat&variant_label=r3i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-all-xGHG-xaer&ensemble_member=ens3>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-2-0&experiment_id=hist-nat>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.hist-all-xGHG-xaer_0201
    * - v2.LR.hist-all-xGHG-xaer_0251
      - 14
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-nat&variant_label=r4i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-all-xGHG-xaer&ensemble_member=ens4>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-nat&variant_label=r4i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-all-xGHG-xaer&ensemble_member=ens4>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-2-0&experiment_id=hist-nat>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.hist-all-xGHG-xaer_0251
    * - v2.LR.hist-all-xGHG-xaer_0301
      - 13
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-nat&variant_label=r5i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-all-xGHG-xaer&ensemble_member=ens5>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=hist-nat&variant_label=r5i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=hist-all-xGHG-xaer&ensemble_member=ens5>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=DAMIP&source_id=E3SM-2-0&experiment_id=hist-nat>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.hist-all-xGHG-xaer_0301
-   * - **LR > AMIP**
+   * - **LR > AMIP** (`Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=CMIP&source_id=E3SM-2-0&experiment_id=amip>`_)
      - 
      - 
      - 
@@ -308,31 +308,31 @@ v2 WaterCycle simulation table
      - 
    * - v2.LR.piClim-control
      - 1
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piClim-control&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piClim-control&ensemble_member=ens1>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piClim-control&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piClim-control&ensemble_member=ens1>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=RFMIP&source_id=E3SM-2-0&experiment_id=piClim-control>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.piClim-control
    * - v2.LR.piClim-histall_0021
      - 3
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piClim-histall&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piClim-histall&ensemble_member=ens1>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piClim-histall&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piClim-histall&ensemble_member=ens1>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=RFMIP&source_id=E3SM-2-0&experiment_id=piClim-histall>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.piClim-histall_0021
    * - v2.LR.piClim-histall_0031
      - 3
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piClim-histall&variant_label=r2i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piClim-histall&ensemble_member=ens2>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piClim-histall&variant_label=r2i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piClim-histall&ensemble_member=ens2>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=RFMIP&source_id=E3SM-2-0&experiment_id=piClim-histall>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.piClim-histall_0031
    * - v2.LR.piClim-histall_0041
      - 3
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piClim-histall&variant_label=r3i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piClim-histall&ensemble_member=ens3>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piClim-histall&variant_label=r3i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piClim-histall&ensemble_member=ens3>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=RFMIP&source_id=E3SM-2-0&experiment_id=piClim-histall>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.piClim-histall_0041
    * - v2.LR.piClim-histaer_0021
      - 3
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piClim-histaer&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piClim-histaer&ensemble_member=ens1>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piClim-histaer&variant_label=r1i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piClim-histaer&ensemble_member=ens1>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=RFMIP&source_id=E3SM-2-0&experiment_id=piClim-histaer>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.piClim-histaer_0021
    * - v2.LR.piClim-histaer_0031
      - 3
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piClim-histaer&variant_label=r2i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piClim-histaer&ensemble_member=ens2>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piClim-histaer&variant_label=r2i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piClim-histaer&ensemble_member=ens2>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=RFMIP&source_id=E3SM-2-0&experiment_id=piClim-histaer>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.piClim-histaer_0031
    * - v2.LR.piClim-histaer_0041
      - 3
-     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piClim-histaer&variant_label=r3i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piClim-histaer&ensemble_member=ens3>`_
+     - `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=E3SM-2-0&experiment_id=piClim-histaer&variant_label=r3i1p1f1>`_, `Native <https://esgf-node.llnl.gov/search/e3sm/?model_version=2_0&experiment=piClim-histaer&ensemble_member=ens3>`_, `Alternative CMIP <https://esgf-node.llnl.gov/search/cmip6/?activity_id=RFMIP&source_id=E3SM-2-0&experiment_id=piClim-histaer>`_
      - /home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.piClim-histaer_0041
    * - **LR > Other**
      - 


### PR DESCRIPTION
The [archived e3sm.org page on released data](https://e3sm.org/data/get-e3sm-data/released-e3sm-data/) has several sub-pages listing ESGF links that weren't present on E3SM Data Docs. This PR addresses that. Resolves #79.