### PR TITLE
Add metadata reviewer

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -8,6 +8,20 @@ $ cd utils
 $ ./generate_html.bash
 ```
 
+Checking for missing data
+=========================
+
+To ensure that `e3sm_data_docs` is not missing any E3SM data currently on ESGF, you can run:
+
+```bash
+cd utils
+python metadata_reviewer.py
+```
+That will create `utils/metadata_review.md`, which will report:
+- Variants on [CMIP6 Metadata](https://github.com/E3SM-Project/CMIP6-Metadata), but not on E3SM Data Docs. These should be added to `e3sm_data_docs` as soon as possible.
+- Variants not on CMIP6 Metadata, but do have an ESGF link on E3SM Data Docs. This should be rare. It would imply that the CMIP6 Metadata is not up-to-date with what's on ESGF.
+- Variants on both CMIP6 Metadata and E3SM Data Docs. No issues here.
+
 Creating reproduction scripts
 =============================
 

--- a/utils/metadata_review.md
+++ b/utils/metadata_review.md
@@ -77,179 +77,179 @@
 
 | Institution ID | Source ID | Activity ID | Experiment ID | Variant Label | Can be found on... |
 |---|---|---|---|---|---|
-| N/A | E3SM-3-0 | N/A | piClim-histGHG | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| N/A | E3SM-3-0 | N/A | piClim-histGHG | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| N/A | E3SM-3-0 | N/A | piClim-histGHG | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| N/A | E3SM-3-0 | N/A | piClim-histGHG | r1i1p1f1 | [v3.LR.piClim-histGHG/v3.LR.piClim-histGHG_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| N/A | E3SM-3-0 | N/A | piClim-histGHG | r2i1p1f1 | [v3.LR.piClim-histGHG/v3.LR.piClim-histGHG_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| N/A | E3SM-3-0 | N/A | piClim-histGHG | r3i1p1f1 | [v3.LR.piClim-histGHG/v3.LR.piClim-histGHG_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
 
 ### Variants on both CMIP6 Metadata and E3SM Data Docs
 
 | Institution ID | Source ID | Activity ID | Experiment ID | Variant Label | Can be found on... |
 |---|---|---|---|---|---|
-| E3SM-Project | E3SM-1-0 | CMIP | abrupt-4xCO2 | r1i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-1-0 | CMIP | amip | r1i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-1-0 | CMIP | amip | r2i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-1-0 | CMIP | amip | r3i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-1-0 | CMIP | historical | r1i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-1-0 | CMIP | historical | r2i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-1-0 | CMIP | historical | r3i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-1-0 | CMIP | historical | r4i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-1-0 | CMIP | historical | r5i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-1-0 | CMIP | piControl | r1i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | 1pctCO2 | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | abrupt-4xCO2 | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | abrupt-4xCO2 | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | amip | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | amip | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | amip | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r10i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r11i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r12i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r13i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r14i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r15i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r16i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r17i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r18i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r19i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r20i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r21i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r4i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r5i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r6i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r7i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r8i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r9i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | piControl | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r4i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r5i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | DAMIP | hist-aer | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | DAMIP | hist-aer | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | DAMIP | hist-aer | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | DAMIP | hist-aer | r4i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | DAMIP | hist-aer | r5i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | DAMIP | hist-nat | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | DAMIP | hist-nat | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | DAMIP | hist-nat | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | DAMIP | hist-nat | r4i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | DAMIP | hist-nat | r5i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histaer | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histaer | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histaer | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histall | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histall | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histall | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | RFMIP AerChemMIP | piClim-control | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r10i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r11i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r12i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r13i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r14i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r15i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r16i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r17i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r18i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r19i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r20i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r21i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r4i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r5i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r6i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r7i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r8i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r9i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0-NARRM | CMIP | 1pctCO2 | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0-NARRM | CMIP | abrupt-4xCO2 | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0-NARRM | CMIP | amip | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0-NARRM | CMIP | amip | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0-NARRM | CMIP | amip | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0-NARRM | CMIP | historical | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0-NARRM | CMIP | historical | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0-NARRM | CMIP | historical | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0-NARRM | CMIP | historical | r4i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0-NARRM | CMIP | historical | r5i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0-NARRM | CMIP | piControl | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-1 | CMIP | 1pctCO2 | r1i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-1 | CMIP | abrupt-4xCO2 | r1i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-1 | CMIP | amip | r1i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-1 | CMIP | historical | r1i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-1 | CMIP | historical | r2i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-1 | CMIP | historical | r3i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-1 | CMIP | historical | r4i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-1 | CMIP | historical | r5i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-1 | CMIP | piControl | r1i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | CMIP | 1pctCO2 | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | CMIP | abrupt-4xCO2 | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | CMIP | amip | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | CMIP | amip | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | CMIP | amip | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | CMIP | historical | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | CMIP | historical | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | CMIP | historical | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | CMIP | historical | r4i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | CMIP | historical | r5i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | CMIP | piControl | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | DAMIP | hist-GHG | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | DAMIP | hist-GHG | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | DAMIP | hist-GHG | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | DAMIP | hist-aer | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | DAMIP | hist-aer | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | DAMIP | hist-aer | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | DAMIP | hist-nat | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | DAMIP | hist-nat | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | DAMIP | hist-nat | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | RFMIP | piClim-control | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histaer | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histaer | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histaer | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histall | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histall | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histall | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r10i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r11i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r12i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r13i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r14i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r15i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r16i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r17i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r18i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r19i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r1i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r20i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r2i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r3i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r4i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r5i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r6i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r7i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r8i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r9i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r10i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r11i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r12i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r13i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r14i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r15i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r16i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r17i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r18i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r19i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r1i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r20i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r2i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r3i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r4i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r5i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r6i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r7i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r8i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r9i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | abrupt-4xCO2 | r1i1p1f1 | [20180215.DECKv1b_abrupt4xCO2.ne30_oEC.edison](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | amip | r1i1p1f1 | [20180316.DECKv1b_A1.ne30_oEC.edison](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | amip | r2i1p1f1 | [20180622.DECKv1b_A2.ne30_oEC.edison](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | amip | r3i1p1f1 | [20180716.DECKv1b_A3.ne30_oEC.edison](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | historical | r1i1p1f1 | [20180215.DECKv1b_H1.ne30_oEC.edison](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | historical | r2i1p1f1 | [20180220.DECKv1b_H2.ne30_oEC.edison](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | historical | r3i1p1f1 | [20180302.DECKv1b_H3.ne30_oEC.edison](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | historical | r4i1p1f1 | [20180305.DECKv1b_H4.ne30_oEC.edison](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | historical | r5i1p1f1 | [20180307.DECKv1b_H5.ne30_oEC.edison](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | piControl | r1i1p1f1 | [20180129.DECKv1b_piControl.ne30_oEC.edison](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | 1pctCO2 | r1i1p1f1 | [v2.LR.1pctCO2_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | abrupt-4xCO2 | r1i1p1f1 | [v2.LR.abrupt-4xCO2_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | abrupt-4xCO2 | r2i1p1f1 | [v2.LR.abrupt-4xCO2_0301](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | amip | r1i1p1f1 | [v2.LR.amip_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | amip | r2i1p1f1 | [v2.LR.amip_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | amip | r3i1p1f1 | [v2.LR.amip_0301](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r10i1p1f1 | [v2.LR.historical_0161](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r11i1p1f1 | [v2.LR.historical_0171](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r12i1p1f1 | [v2.LR.historical_0181](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r13i1p1f1 | [v2.LR.historical_0191](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r14i1p1f1 | [v2.LR.historical_0211](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r15i1p1f1 | [v2.LR.historical_0221](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r16i1p1f1 | [v2.LR.historical_0231](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r17i1p1f1 | [v2.LR.historical_0241](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r18i1p1f1 | [v2.LR.historical_0261](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r19i1p1f1 | [v2.LR.historical_0271](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r1i1p1f1 | [v2.LR.historical_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r20i1p1f1 | [v2.LR.historical_0281](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r21i1p1f1 | [v2.LR.historical_0291](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r2i1p1f1 | [v2.LR.historical_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r3i1p1f1 | [v2.LR.historical_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r4i1p1f1 | [v2.LR.historical_0251](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r5i1p1f1 | [v2.LR.historical_0301](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r6i1p1f1 | [v2.LR.historical_0111](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r7i1p1f1 | [v2.LR.historical_0121](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r8i1p1f1 | [v2.LR.historical_0131](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r9i1p1f1 | [v2.LR.historical_0141](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | piControl | r1i1p1f1 | [v2.LR.piControl](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r1i1p1f1 | [v2.LR.hist-GHG_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r2i1p1f1 | [v2.LR.hist-GHG_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r3i1p1f1 | [v2.LR.hist-GHG_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r4i1p1f1 | [v2.LR.hist-GHG_0251](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r5i1p1f1 | [v2.LR.hist-GHG_0301](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-aer | r1i1p1f1 | [v2.LR.hist-aer_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-aer | r2i1p1f1 | [v2.LR.hist-aer_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-aer | r3i1p1f1 | [v2.LR.hist-aer_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-aer | r4i1p1f1 | [v2.LR.hist-aer_0251](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-aer | r5i1p1f1 | [v2.LR.hist-aer_0301](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-nat | r1i1p1f1 | [v2.LR.hist-all-xGHG-xaer_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-nat | r2i1p1f1 | [v2.LR.hist-all-xGHG-xaer_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-nat | r3i1p1f1 | [v2.LR.hist-all-xGHG-xaer_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-nat | r4i1p1f1 | [v2.LR.hist-all-xGHG-xaer_0251](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-nat | r5i1p1f1 | [v2.LR.hist-all-xGHG-xaer_0301](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histaer | r1i1p1f1 | [v2.LR.piClim-histaer_0021](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histaer | r2i1p1f1 | [v2.LR.piClim-histaer_0031](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histaer | r3i1p1f1 | [v2.LR.piClim-histaer_0041](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histall | r1i1p1f1 | [v2.LR.piClim-histall_0021](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histall | r2i1p1f1 | [v2.LR.piClim-histall_0031](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histall | r3i1p1f1 | [v2.LR.piClim-histall_0041](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | RFMIP AerChemMIP | piClim-control | r1i1p1f1 | [v2.LR.piClim-control](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r10i1p1f1 | [v2.LR.SSP370_0161](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r11i1p1f1 | [v2.LR.SSP370_0171](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r12i1p1f1 | [v2.LR.SSP370_0181](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r13i1p1f1 | [v2.LR.SSP370_0191](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r14i1p1f1 | [v2.LR.SSP370_0211](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r15i1p1f1 | [v2.LR.SSP370_0221](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r16i1p1f1 | [v2.LR.SSP370_0231](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r17i1p1f1 | [v2.LR.SSP370_0241](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r18i1p1f1 | [v2.LR.SSP370_0261](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r19i1p1f1 | [v2.LR.SSP370_0271](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r1i1p1f1 | [v2.LR.SSP370_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r20i1p1f1 | [v2.LR.SSP370_0281](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r21i1p1f1 | [v2.LR.SSP370_0291](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r2i1p1f1 | [v2.LR.SSP370_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r3i1p1f1 | [v2.LR.SSP370_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r4i1p1f1 | [v2.LR.SSP370_0251](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r5i1p1f1 | [v2.LR.SSP370_0301](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r6i1p1f1 | [v2.LR.SSP370_0111](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r7i1p1f1 | [v2.LR.SSP370_0121](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r8i1p1f1 | [v2.LR.SSP370_0131](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r9i1p1f1 | [v2.LR.SSP370_0141](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | 1pctCO2 | r1i1p1f1 | [v2.NARRM.1pctCO2_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | abrupt-4xCO2 | r1i1p1f1 | [v2.NARRM.abrupt-4xCO2_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | amip | r1i1p1f1 | [v2.NARRM.amip_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | amip | r2i1p1f1 | [v2.NARRM.amip_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | amip | r3i1p1f1 | [v2.NARRM.amip_0301](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | historical | r1i1p1f1 | [v2.NARRM.historical_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | historical | r2i1p1f1 | [v2.NARRM.historical_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | historical | r3i1p1f1 | [v2.NARRM.historical_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | historical | r4i1p1f1 | [v2.NARRM.historical_0251](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | historical | r5i1p1f1 | [v2.NARRM.historical_0301](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | piControl | r1i1p1f1 | [v2.NARRM.piControl](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | 1pctCO2 | r1i1p1f1 | [v2_1.LR.1pctCO2_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | abrupt-4xCO2 | r1i1p1f1 | [v2_1.LR.abrupt-4xCO2_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | amip | r1i1p1f1 | [v2_1.LR.amip_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | historical | r1i1p1f1 | [v2_1.LR.historical_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | historical | r2i1p1f1 | [v2_1.LR.historical_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | historical | r3i1p1f1 | [v2_1.LR.historical_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | historical | r4i1p1f1 | [v2_1.LR.historical_0251](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | historical | r5i1p1f1 | [v2_1.LR.historical_0301](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | piControl | r1i1p1f1 | [v2_1.LR.piControl](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | 1pctCO2 | r1i1p1f1 | [v3.LR.1pctCO2_0101_bcdt15m](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | abrupt-4xCO2 | r1i1p1f1 | [v3.LR.abrupt-4xCO2_0101_bcdt15m](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | amip | r1i1p1f1 | [v3.LR.amip_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | amip | r2i1p1f1 | [v3.LR.amip_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | amip | r3i1p1f1 | [v3.LR.amip_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r1i1p1f1 | [v3.LR.historical_0051](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r2i1p1f1 | [v3.LR.historical_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r3i1p1f1 | [v3.LR.historical_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r4i1p1f1 | [v3.LR.historical_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r5i1p1f1 | [v3.LR.historical_0251](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | piControl | r1i1p1f1 | [v3.LR.piControl](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-GHG | r1i1p1f1 | [v3.LR.hist-GHG_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-GHG | r2i1p1f1 | [v3.LR.hist-GHG_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-GHG | r3i1p1f1 | [v3.LR.hist-GHG_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-aer | r1i1p1f1 | [v3.LR.hist-aer_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-aer | r2i1p1f1 | [v3.LR.hist-aer_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-aer | r3i1p1f1 | [v3.LR.hist-aer_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-nat | r1i1p1f1 | [v3.LR.hist-xGHG-xaer_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-nat | r2i1p1f1 | [v3.LR.hist-xGHG-xaer_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-nat | r3i1p1f1 | [v3.LR.hist-xGHG-xaer_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-control | r1i1p1f1 | [v3.LR.piClim-control-iceini](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histaer | r1i1p1f1 | [v3.LR.piClim-histaer/v3.LR.piClim-histaer_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histaer | r2i1p1f1 | [v3.LR.piClim-histaer/v3.LR.piClim-histaer_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histaer | r3i1p1f1 | [v3.LR.piClim-histaer/v3.LR.piClim-histaer_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histall | r1i1p1f1 | [v3.LR.piClim-histall/v3.LR.piClim-histall_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histall | r2i1p1f1 | [v3.LR.piClim-histall/v3.LR.piClim-histall_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histall | r3i1p1f1 | [v3.LR.piClim-histall/v3.LR.piClim-histall_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r10i2p2f1 | [LE_historical_ens10](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r11i2p2f1 | [LE_historical_ens11](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r12i2p2f1 | [LE_historical_ens12](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r13i2p2f1 | [LE_historical_ens13](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r14i2p2f1 | [LE_historical_ens14](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r15i2p2f1 | [LE_historical_ens15](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r16i2p2f1 | [LE_historical_ens16](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r17i2p2f1 | [LE_historical_ens17](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r18i2p2f1 | [LE_historical_ens18](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r19i2p2f1 | [LE_historical_ens19](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r1i2p2f1 | [LE_historical_ens1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r20i2p2f1 | [LE_historical_ens20](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r2i2p2f1 | [LE_historical_ens2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r3i2p2f1 | [LE_historical_ens3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r4i2p2f1 | [LE_historical_ens4](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r5i2p2f1 | [LE_historical_ens5](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r6i2p2f1 | [LE_historical_ens6](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r7i2p2f1 | [LE_historical_ens7](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r8i2p2f1 | [LE_historical_ens8](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r9i2p2f1 | [LE_historical_ens9](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r10i2p2f1 | [LE_ssp370_ens10](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r11i2p2f1 | [LE_ssp370_ens11](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r12i2p2f1 | [LE_ssp370_ens12](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r13i2p2f1 | [LE_ssp370_ens13](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r14i2p2f1 | [LE_ssp370_ens14](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r15i2p2f1 | [LE_ssp370_ens15](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r16i2p2f1 | [LE_ssp370_ens16](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r17i2p2f1 | [LE_ssp370_ens17](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r18i2p2f1 | [LE_ssp370_ens18](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r19i2p2f1 | [LE_ssp370_ens19](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r1i2p2f1 | [LE_ssp370_ens1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r20i2p2f1 | [LE_ssp370_ens20](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r2i2p2f1 | [LE_ssp370_ens2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r3i2p2f1 | [LE_ssp370_ens3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r4i2p2f1 | [LE_ssp370_ens4](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r5i2p2f1 | [LE_ssp370_ens5](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r6i2p2f1 | [LE_ssp370_ens6](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r7i2p2f1 | [LE_ssp370_ens7](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r8i2p2f1 | [LE_ssp370_ens8](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r9i2p2f1 | [LE_ssp370_ens9](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |

--- a/utils/metadata_review.md
+++ b/utils/metadata_review.md
@@ -24,6 +24,10 @@
 | E3SM-Project | E3SM-1-1-ECA | CMIP | historical | r1i1p1f1 |  |
 | E3SM-Project | E3SM-1-1-ECA | CMIP | piControl | r1i1p1f1 |  |
 | E3SM-Project | E3SM-1-1-ECA | ScenarioMIP | ssp585 | r1i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r6i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r7i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r8i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r9i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | CMIP | historical | r10i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | CMIP | historical | r11i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | CMIP | historical | r12i1p1f1 |  |
@@ -40,13 +44,15 @@
 | E3SM-Project | E3SM-3-0 | CMIP | historical | r23i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | CMIP | historical | r24i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | CMIP | historical | r25i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | CMIP | historical | r6i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | CMIP | historical | r7i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | CMIP | historical | r8i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | CMIP | historical | r9i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histghg | r1i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histghg | r2i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histghg | r3i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r1i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r2i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r3i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r4i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r5i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r6i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r7i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r8i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r9i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r10i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r11i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r12i1p1f1 |  |
@@ -57,29 +63,17 @@
 | E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r17i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r18i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r19i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r1i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r20i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r21i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r22i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r23i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r24i1p1f1 |  |
 | E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r25i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r2i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r3i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r4i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r5i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r6i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r7i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r8i1p1f1 |  |
-| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r9i1p1f1 |  |
 
 ### Variants not on CMIP6 Metadata, but on E3SM Data Docs
 
 | Institution ID | Source ID | Activity ID | Experiment ID | Variant Label | Can be found on... |
 |---|---|---|---|---|---|
-| N/A | E3SM-3-0 | N/A | piClim-histGHG | r1i1p1f1 | [v3.LR.piClim-histGHG/v3.LR.piClim-histGHG_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| N/A | E3SM-3-0 | N/A | piClim-histGHG | r2i1p1f1 | [v3.LR.piClim-histGHG/v3.LR.piClim-histGHG_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
-| N/A | E3SM-3-0 | N/A | piClim-histGHG | r3i1p1f1 | [v3.LR.piClim-histGHG/v3.LR.piClim-histGHG_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
 
 ### Variants on both CMIP6 Metadata and E3SM Data Docs
 
@@ -101,6 +95,15 @@
 | E3SM-Project | E3SM-2-0 | CMIP | amip | r1i1p1f1 | [v2.LR.amip_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | CMIP | amip | r2i1p1f1 | [v2.LR.amip_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | CMIP | amip | r3i1p1f1 | [v2.LR.amip_0301](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r1i1p1f1 | [v2.LR.historical_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r2i1p1f1 | [v2.LR.historical_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r3i1p1f1 | [v2.LR.historical_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r4i1p1f1 | [v2.LR.historical_0251](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r5i1p1f1 | [v2.LR.historical_0301](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r6i1p1f1 | [v2.LR.historical_0111](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r7i1p1f1 | [v2.LR.historical_0121](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r8i1p1f1 | [v2.LR.historical_0131](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r9i1p1f1 | [v2.LR.historical_0141](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | CMIP | historical | r10i1p1f1 | [v2.LR.historical_0161](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | CMIP | historical | r11i1p1f1 | [v2.LR.historical_0171](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | CMIP | historical | r12i1p1f1 | [v2.LR.historical_0181](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
@@ -111,17 +114,8 @@
 | E3SM-Project | E3SM-2-0 | CMIP | historical | r17i1p1f1 | [v2.LR.historical_0241](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | CMIP | historical | r18i1p1f1 | [v2.LR.historical_0261](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | CMIP | historical | r19i1p1f1 | [v2.LR.historical_0271](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r1i1p1f1 | [v2.LR.historical_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | CMIP | historical | r20i1p1f1 | [v2.LR.historical_0281](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | CMIP | historical | r21i1p1f1 | [v2.LR.historical_0291](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r2i1p1f1 | [v2.LR.historical_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r3i1p1f1 | [v2.LR.historical_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r4i1p1f1 | [v2.LR.historical_0251](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r5i1p1f1 | [v2.LR.historical_0301](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r6i1p1f1 | [v2.LR.historical_0111](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r7i1p1f1 | [v2.LR.historical_0121](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r8i1p1f1 | [v2.LR.historical_0131](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | CMIP | historical | r9i1p1f1 | [v2.LR.historical_0141](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | CMIP | piControl | r1i1p1f1 | [v2.LR.piControl](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r1i1p1f1 | [v2.LR.hist-GHG_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r2i1p1f1 | [v2.LR.hist-GHG_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
@@ -145,6 +139,15 @@
 | E3SM-Project | E3SM-2-0 | RFMIP | piClim-histall | r2i1p1f1 | [v2.LR.piClim-histall_0031](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | RFMIP | piClim-histall | r3i1p1f1 | [v2.LR.piClim-histall_0041](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | RFMIP AerChemMIP | piClim-control | r1i1p1f1 | [v2.LR.piClim-control](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r1i1p1f1 | [v2.LR.SSP370_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r2i1p1f1 | [v2.LR.SSP370_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r3i1p1f1 | [v2.LR.SSP370_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r4i1p1f1 | [v2.LR.SSP370_0251](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r5i1p1f1 | [v2.LR.SSP370_0301](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r6i1p1f1 | [v2.LR.SSP370_0111](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r7i1p1f1 | [v2.LR.SSP370_0121](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r8i1p1f1 | [v2.LR.SSP370_0131](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r9i1p1f1 | [v2.LR.SSP370_0141](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r10i1p1f1 | [v2.LR.SSP370_0161](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r11i1p1f1 | [v2.LR.SSP370_0171](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r12i1p1f1 | [v2.LR.SSP370_0181](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
@@ -155,17 +158,8 @@
 | E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r17i1p1f1 | [v2.LR.SSP370_0241](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r18i1p1f1 | [v2.LR.SSP370_0261](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r19i1p1f1 | [v2.LR.SSP370_0271](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r1i1p1f1 | [v2.LR.SSP370_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r20i1p1f1 | [v2.LR.SSP370_0281](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r21i1p1f1 | [v2.LR.SSP370_0291](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r2i1p1f1 | [v2.LR.SSP370_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r3i1p1f1 | [v2.LR.SSP370_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r4i1p1f1 | [v2.LR.SSP370_0251](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r5i1p1f1 | [v2.LR.SSP370_0301](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r6i1p1f1 | [v2.LR.SSP370_0111](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r7i1p1f1 | [v2.LR.SSP370_0121](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r8i1p1f1 | [v2.LR.SSP370_0131](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
-| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r9i1p1f1 | [v2.LR.SSP370_0141](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0-NARRM | CMIP | 1pctCO2 | r1i1p1f1 | [v2.NARRM.1pctCO2_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0-NARRM | CMIP | abrupt-4xCO2 | r1i1p1f1 | [v2.NARRM.abrupt-4xCO2_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-2-0-NARRM | CMIP | amip | r1i1p1f1 | [v2.NARRM.amip_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
@@ -213,6 +207,18 @@
 | E3SM-Project | E3SM-3-0 | RFMIP | piClim-histall | r1i1p1f1 | [v3.LR.piClim-histall/v3.LR.piClim-histall_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-3-0 | RFMIP | piClim-histall | r2i1p1f1 | [v3.LR.piClim-histall/v3.LR.piClim-histall_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
 | E3SM-Project | E3SM-3-0 | RFMIP | piClim-histall | r3i1p1f1 | [v3.LR.piClim-histall/v3.LR.piClim-histall_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histghg | r1i1p1f1 | [v3.LR.piClim-histGHG/v3.LR.piClim-histGHG_0101](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histghg | r2i1p1f1 | [v3.LR.piClim-histGHG/v3.LR.piClim-histGHG_0151](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histghg | r3i1p1f1 | [v3.LR.piClim-histGHG/v3.LR.piClim-histGHG_0201](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r1i2p2f1 | [LE_historical_ens1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r2i2p2f1 | [LE_historical_ens2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r3i2p2f1 | [LE_historical_ens3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r4i2p2f1 | [LE_historical_ens4](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r5i2p2f1 | [LE_historical_ens5](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r6i2p2f1 | [LE_historical_ens6](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r7i2p2f1 | [LE_historical_ens7](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r8i2p2f1 | [LE_historical_ens8](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r9i2p2f1 | [LE_historical_ens9](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
 | UCSB | E3SM-1-0 | CMIP | historical | r10i2p2f1 | [LE_historical_ens10](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
 | UCSB | E3SM-1-0 | CMIP | historical | r11i2p2f1 | [LE_historical_ens11](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
 | UCSB | E3SM-1-0 | CMIP | historical | r12i2p2f1 | [LE_historical_ens12](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
@@ -223,16 +229,16 @@
 | UCSB | E3SM-1-0 | CMIP | historical | r17i2p2f1 | [LE_historical_ens17](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
 | UCSB | E3SM-1-0 | CMIP | historical | r18i2p2f1 | [LE_historical_ens18](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
 | UCSB | E3SM-1-0 | CMIP | historical | r19i2p2f1 | [LE_historical_ens19](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r1i2p2f1 | [LE_historical_ens1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
 | UCSB | E3SM-1-0 | CMIP | historical | r20i2p2f1 | [LE_historical_ens20](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r2i2p2f1 | [LE_historical_ens2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r3i2p2f1 | [LE_historical_ens3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r4i2p2f1 | [LE_historical_ens4](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r5i2p2f1 | [LE_historical_ens5](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r6i2p2f1 | [LE_historical_ens6](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r7i2p2f1 | [LE_historical_ens7](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r8i2p2f1 | [LE_historical_ens8](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | CMIP | historical | r9i2p2f1 | [LE_historical_ens9](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r1i2p2f1 | [LE_ssp370_ens1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r2i2p2f1 | [LE_ssp370_ens2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r3i2p2f1 | [LE_ssp370_ens3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r4i2p2f1 | [LE_ssp370_ens4](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r5i2p2f1 | [LE_ssp370_ens5](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r6i2p2f1 | [LE_ssp370_ens6](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r7i2p2f1 | [LE_ssp370_ens7](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r8i2p2f1 | [LE_ssp370_ens8](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r9i2p2f1 | [LE_ssp370_ens9](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
 | UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r10i2p2f1 | [LE_ssp370_ens10](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
 | UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r11i2p2f1 | [LE_ssp370_ens11](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
 | UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r12i2p2f1 | [LE_ssp370_ens12](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
@@ -243,13 +249,4 @@
 | UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r17i2p2f1 | [LE_ssp370_ens17](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
 | UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r18i2p2f1 | [LE_ssp370_ens18](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
 | UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r19i2p2f1 | [LE_ssp370_ens19](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r1i2p2f1 | [LE_ssp370_ens1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
 | UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r20i2p2f1 | [LE_ssp370_ens20](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r2i2p2f1 | [LE_ssp370_ens2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r3i2p2f1 | [LE_ssp370_ens3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r4i2p2f1 | [LE_ssp370_ens4](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r5i2p2f1 | [LE_ssp370_ens5](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r6i2p2f1 | [LE_ssp370_ens6](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r7i2p2f1 | [LE_ssp370_ens7](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r8i2p2f1 | [LE_ssp370_ens8](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
-| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r9i2p2f1 | [LE_ssp370_ens9](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |

--- a/utils/metadata_review.md
+++ b/utils/metadata_review.md
@@ -1,0 +1,255 @@
+### Variants on CMIP6 Metadata, but not on E3SM Data Docs
+
+| Institution ID | Source ID | Activity ID | Experiment ID | Variant Label | Can be found on... |
+|---|---|---|---|---|---|
+| E3SM-Project | E3SM-1-0 | CFMIP | amip-piForcing | r1i1p1f1 |  |
+| E3SM-Project | E3SM-1-0 | CFMIP | amip-piForcing | r2i1p1f1 |  |
+| E3SM-Project | E3SM-1-0 | CFMIP | amip-piForcing | r3i1p1f1 |  |
+| E3SM-Project | E3SM-1-0 | CMIP | 1pctCO2 | r1i1p1f1 |  |
+| E3SM-Project | E3SM-1-0 | DAMIP | hist-GHG | r1i1p1f1 |  |
+| E3SM-Project | E3SM-1-0 | DAMIP | hist-GHG | r2i1p1f1 |  |
+| E3SM-Project | E3SM-1-0 | DAMIP | hist-GHG | r3i1p1f1 |  |
+| E3SM-Project | E3SM-1-0 | ScenarioMIP | ssp585 | r1i1p1f1 |  |
+| E3SM-Project | E3SM-1-0 | ScenarioMIP | ssp585 | r2i1p1f1 |  |
+| E3SM-Project | E3SM-1-0 | ScenarioMIP | ssp585 | r3i1p1f1 |  |
+| E3SM-Project | E3SM-1-0 | ScenarioMIP | ssp585 | r4i1p1f1 |  |
+| E3SM-Project | E3SM-1-0 | ScenarioMIP | ssp585 | r5i1p1f1 |  |
+| E3SM-Project | E3SM-1-1 | C4MIP | hist-bgc | r1i1p1f1 |  |
+| E3SM-Project | E3SM-1-1 | C4MIP | ssp585-bgc | r1i1p1f1 |  |
+| E3SM-Project | E3SM-1-1 | CMIP | historical | r1i1p1f1 |  |
+| E3SM-Project | E3SM-1-1 | CMIP | piControl | r1i1p1f1 |  |
+| E3SM-Project | E3SM-1-1 | ScenarioMIP | ssp585 | r1i1p1f1 |  |
+| E3SM-Project | E3SM-1-1-ECA | C4MIP | hist-bgc | r1i1p1f1 |  |
+| E3SM-Project | E3SM-1-1-ECA | C4MIP | ssp585-bgc | r1i1p1f1 |  |
+| E3SM-Project | E3SM-1-1-ECA | CMIP | historical | r1i1p1f1 |  |
+| E3SM-Project | E3SM-1-1-ECA | CMIP | piControl | r1i1p1f1 |  |
+| E3SM-Project | E3SM-1-1-ECA | ScenarioMIP | ssp585 | r1i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r10i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r11i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r12i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r13i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r14i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r15i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r16i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r17i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r18i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r19i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r20i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r21i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r22i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r23i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r24i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r25i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r6i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r7i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r8i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r9i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histghg | r1i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histghg | r2i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histghg | r3i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r10i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r11i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r12i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r13i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r14i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r15i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r16i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r17i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r18i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r19i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r1i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r20i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r21i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r22i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r23i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r24i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r25i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r2i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r3i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r4i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r5i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r6i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r7i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r8i1p1f1 |  |
+| E3SM-Project | E3SM-3-0 | ScenarioMIP | ssp245 | r9i1p1f1 |  |
+
+### Variants not on CMIP6 Metadata, but on E3SM Data Docs
+
+| Institution ID | Source ID | Activity ID | Experiment ID | Variant Label | Can be found on... |
+|---|---|---|---|---|---|
+| N/A | E3SM-3-0 | N/A | piClim-histGHG | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| N/A | E3SM-3-0 | N/A | piClim-histGHG | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| N/A | E3SM-3-0 | N/A | piClim-histGHG | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+
+### Variants on both CMIP6 Metadata and E3SM Data Docs
+
+| Institution ID | Source ID | Activity ID | Experiment ID | Variant Label | Can be found on... |
+|---|---|---|---|---|---|
+| E3SM-Project | E3SM-1-0 | CMIP | abrupt-4xCO2 | r1i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | amip | r1i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | amip | r2i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | amip | r3i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | historical | r1i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | historical | r2i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | historical | r3i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | historical | r4i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | historical | r5i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-1-0 | CMIP | piControl | r1i1p1f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | 1pctCO2 | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | abrupt-4xCO2 | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | abrupt-4xCO2 | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | amip | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | amip | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | amip | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r10i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r11i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r12i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r13i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r14i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r15i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r16i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r17i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r18i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r19i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r20i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r21i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r4i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r5i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r6i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r7i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r8i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | historical | r9i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | CMIP | piControl | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r4i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-GHG | r5i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-aer | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-aer | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-aer | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-aer | r4i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-aer | r5i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-nat | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-nat | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-nat | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-nat | r4i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | DAMIP | hist-nat | r5i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histaer | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histaer | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histaer | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histall | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histall | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | RFMIP | piClim-histall | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | RFMIP AerChemMIP | piClim-control | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r10i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r11i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r12i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r13i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r14i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r15i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r16i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r17i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r18i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r19i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r20i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r21i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r4i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r5i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r6i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r7i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r8i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0 | ScenarioMIP AerChemMIP | ssp370 | r9i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | 1pctCO2 | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | abrupt-4xCO2 | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | amip | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | amip | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | amip | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | historical | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | historical | r2i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | historical | r3i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | historical | r4i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | historical | r5i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-0-NARRM | CMIP | piControl | r1i1p1f1 | [v2](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | 1pctCO2 | r1i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | abrupt-4xCO2 | r1i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | amip | r1i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | historical | r1i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | historical | r2i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | historical | r3i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | historical | r4i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | historical | r5i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-2-1 | CMIP | piControl | r1i1p1f1 | [v2.1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v2.1/WaterCycle/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | 1pctCO2 | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | abrupt-4xCO2 | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | amip | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | amip | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | amip | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r4i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | historical | r5i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | CMIP | piControl | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-GHG | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-GHG | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-GHG | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-aer | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-aer | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-aer | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-nat | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-nat | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | DAMIP | hist-nat | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-control | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histaer | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histaer | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histaer | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histall | r1i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histall | r2i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| E3SM-Project | E3SM-3-0 | RFMIP | piClim-histall | r3i1p1f1 | [v3](https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r10i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r11i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r12i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r13i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r14i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r15i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r16i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r17i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r18i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r19i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r1i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r20i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r2i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r3i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r4i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r5i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r6i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r7i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r8i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | CMIP | historical | r9i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r10i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r11i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r12i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r13i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r14i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r15i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r16i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r17i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r18i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r19i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r1i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r20i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r2i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r3i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r4i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r5i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r6i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r7i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r8i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |
+| UCSB | E3SM-1-0 | ScenarioMIP AerChemMIP | ssp370 | r9i2p2f1 | [v1](https://docs.e3sm.org/e3sm_data_docs/_build/html/v1/WaterCycle/simulation_data/simulation_table.html) |

--- a/utils/metadata_reviewer.py
+++ b/utils/metadata_reviewer.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python
+"""
+Cross-check CMIP6-Metadata JSON files against the ESGF links published in the
+E3SM Data Docs simulation tables.
+
+For every variant described by a CMIP6-Metadata JSON file, this script tries
+to find a matching ESGF link in one of the `simulation_table.rst` pages in
+the E3SM Data Docs repo. It then reports, as three Markdown tables:
+
+  1. Variants on CMIP6 Metadata, but not on E3SM Data Docs
+  2. Variants not on CMIP6 Metadata, but on E3SM Data Docs
+  3. Variants on both CMIP6 Metadata and E3SM Data Docs
+
+NOTE on institution_id / activity_id:
+The ESGF search links embedded in the data-docs tables only ever encode
+`source_id`, `experiment_id`, and `variant_label` (as query parameters, or as
+a URL-encoded JSON blob in an `activeFacets` parameter). They do not encode
+`institution_id` or `activity_id`. Because of that, a Variant's *identity*
+(used for matching/hashing/equality) is based only on
+(source_id, experiment_id, variant_label). When a variant is discovered only
+from a data-docs link (i.e. it has no corresponding CMIP6-Metadata JSON),
+its institution_id/activity_id fields are set to "N/A" rather than guessed.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+from urllib.parse import urlparse, parse_qs
+
+# Set these parameters before running the script:
+CMIP6_METADATA_REPO = "/home/ac.forsyth2/ez/CMIP6-Metadata"
+DATA_DOCS_REPO = "/home/ac.forsyth2/ez/e3sm_data_docs/"
+
+# Fields that are not derivable from an ESGF link alone.
+UNKNOWN = "N/A"
+
+
+class Variant(object):
+    def __init__(
+        self,
+        institution_id: str = "",
+        source_id: str = "",
+        activity_id: str = "",
+        experiment_id: str = "",
+        variant_label: str = "",
+        e3sm_data_docs_page: str = "",
+    ):
+        self.institution_id: str = institution_id
+        self.source_id: str = source_id
+        self.activity_id: str = activity_id
+        self.experiment_id: str = experiment_id
+        self.variant_label: str = variant_label
+        self.e3sm_data_docs_page: str = e3sm_data_docs_page
+
+    def _key(self) -> Tuple[str, str, str]:
+        # institution_id / activity_id are deliberately excluded from the
+        # identity key -- see module docstring.
+        return (self.source_id, self.experiment_id, self.variant_label)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Variant):
+            return NotImplemented
+        return self._key() == other._key()
+
+    def __hash__(self) -> int:
+        return hash(self._key())
+
+    def __repr__(self) -> str:
+        return (
+            f"Variant(institution_id={self.institution_id!r}, "
+            f"source_id={self.source_id!r}, activity_id={self.activity_id!r}, "
+            f"experiment_id={self.experiment_id!r}, "
+            f"variant_label={self.variant_label!r}, "
+            f"e3sm_data_docs_page={self.e3sm_data_docs_page!r})"
+        )
+
+
+# CMIP6-Metadata JSON files are named "<experiment_id>_<variant_label>.json",
+# e.g. "1pctCO2_r1i1p1f1.json".
+FILENAME_RE = re.compile(r"^(?P<experiment_id>.+)_(?P<variant_label>r\d+i\d+p\d+f\d+)$")
+
+
+def create_variant_from_json(json_path: str) -> Variant:
+    with open(json_path) as f:
+        metadata: Dict = json.load(f)
+
+    # "#..." keys are just documentation/notes embedded in the CMIP6-Metadata
+    # JSON files -- ignore them.
+    metadata = {k: v for k, v in metadata.items() if not k.startswith("#")}
+
+    # variant_label isn't a top-level JSON field, but it's encoded in the
+    # filename ("<experiment_id>_<variant_label>.json") and can also be
+    # reconstructed from the realization/initialization/physics/forcing
+    # index fields. Prefer the filename (it's the more direct source and
+    # doesn't assume the index fields are always present/well-formed), but
+    # cross-check against the indices when they're available and warn on a
+    # mismatch rather than silently picking one.
+    stem = Path(json_path).stem
+    filename_match = FILENAME_RE.match(stem)
+    variant_label = filename_match.group("variant_label") if filename_match else None
+
+    if all(
+        k in metadata
+        for k in (
+            "realization_index",
+            "initialization_index",
+            "physics_index",
+            "forcing_index",
+        )
+    ):
+        variant_label_from_indices = (
+            f"r{metadata['realization_index']}"
+            f"i{metadata['initialization_index']}"
+            f"p{metadata['physics_index']}"
+            f"f{metadata['forcing_index']}"
+        )
+        if variant_label is None:
+            variant_label = variant_label_from_indices
+        elif variant_label != variant_label_from_indices:
+            print(
+                f"WARNING: {json_path}: variant_label from filename "
+                f"({variant_label!r}) disagrees with variant_label computed "
+                f"from index fields ({variant_label_from_indices!r}); using "
+                f"the filename's value."
+            )
+
+    if variant_label is None:
+        raise ValueError(
+            f"{json_path}: could not determine variant_label from the "
+            f"filename or from index fields."
+        )
+
+    return Variant(
+        institution_id=metadata.get("institution_id", ""),
+        source_id=metadata.get("source_id", ""),
+        activity_id=metadata.get("activity_id", ""),
+        experiment_id=metadata.get("experiment_id", ""),
+        variant_label=variant_label,
+        e3sm_data_docs_page="",
+    )
+
+
+def find_all_variants_from_cmip6_metadata() -> Set[Variant]:
+    variants_from_cmip6_metadata: Set[Variant] = set()
+    for json_path in Path(CMIP6_METADATA_REPO).glob("*/*.json"):
+        variants_from_cmip6_metadata.add(create_variant_from_json(str(json_path)))
+    return variants_from_cmip6_metadata
+
+
+# Matches an ESGF search link labeled "CMIP" in an RST hyperlink, e.g.:
+#   `CMIP <https://esgf-node.llnl.gov/search/cmip6/?source_id=...>`_
+CMIP_LINK_RE = re.compile(r"`CMIP\s*<([^>]+)>`_")
+
+# A new list-table row: "   * - <first column>"
+ROW_START_RE = re.compile(r"^\s*\*\s*-\s?(.*)$")
+# A continuation column of the current row: "     - <column>"
+COL_CONT_RE = re.compile(r"^\s*-\s?(.*)$")
+
+
+def _parse_esgf_url(url: str) -> Optional[Tuple[str, str, str]]:
+    """Extract (source_id, experiment_id, variant_label) from an ESGF link.
+
+    Two URL flavors are supported:
+      - Simple query params, e.g. esgf-node.llnl.gov/search/cmip6/?source_id=...
+      - A URL-encoded JSON blob in an `activeFacets` param, e.g. aims2.llnl.gov
+    """
+    query = parse_qs(urlparse(url).query)
+
+    if "activeFacets" in query:
+        try:
+            facets = json.loads(query["activeFacets"][0])
+        except (json.JSONDecodeError, IndexError):
+            return None
+        source_id = facets.get("source_id")
+        experiment_id = facets.get("experiment_id")
+        variant_label = facets.get("variant_label")
+    else:
+        source_id = query.get("source_id", [None])[0]
+        experiment_id = query.get("experiment_id", [None])[0]
+        variant_label = query.get("variant_label", [None])[0]
+
+    if not (source_id and experiment_id and variant_label):
+        return None
+
+    return source_id, experiment_id, variant_label
+
+
+def _parse_list_table_rows(rst_path: str) -> List[List[str]]:
+    """Parse a Sphinx `.. list-table::` into a list of rows of column text."""
+    rows: List[List[str]] = []
+    current_row: Optional[List[str]] = None
+
+    with open(rst_path) as f:
+        for line in f:
+            row_match = ROW_START_RE.match(line)
+            if row_match:
+                if current_row is not None:
+                    rows.append(current_row)
+                current_row = [row_match.group(1).strip()]
+                continue
+
+            if current_row is not None:
+                col_match = COL_CONT_RE.match(line)
+                if col_match:
+                    current_row.append(col_match.group(1).strip())
+                    continue
+
+    if current_row is not None:
+        rows.append(current_row)
+
+    return rows
+
+
+def collect_links_from_table(rst_path: str) -> List[Variant]:
+    variants: List[Variant] = []
+
+    rows = _parse_list_table_rows(rst_path)
+    if not rows:
+        return variants
+
+    # `:header-rows: 1` -- the first row is the header; use it to find the
+    # "ESGF Links" column index rather than assuming a fixed position.
+    header = rows[0]
+    esgf_col_idx = next(
+        (i for i, col in enumerate(header) if "ESGF Links" in col), None
+    )
+    if esgf_col_idx is None:
+        return variants
+
+    for row in rows[1:]:
+        if esgf_col_idx >= len(row):
+            continue
+        esgf_cell = row[esgf_col_idx]
+
+        match = CMIP_LINK_RE.search(esgf_cell)
+        if not match:
+            continue
+
+        parsed = _parse_esgf_url(match.group(1))
+        if parsed is None:
+            continue
+
+        source_id, experiment_id, variant_label = parsed
+        variants.append(
+            Variant(
+                institution_id=UNKNOWN,
+                source_id=source_id,
+                activity_id=UNKNOWN,
+                experiment_id=experiment_id,
+                variant_label=variant_label,
+                e3sm_data_docs_page=rst_path,
+            )
+        )
+
+    return variants
+
+
+def process_links_in_data_docs(variants_from_cmip6_metadata: Set[Variant]) -> Set[Variant]:
+    variants_not_in_cmip6_metadata: Set[Variant] = set()
+
+    # Lookup by identity key so we can mutate the *actual* objects that live
+    # in `variants_from_cmip6_metadata` when we find a matching link.
+    lookup: Dict[Tuple[str, str, str], Variant] = {
+        v._key(): v for v in variants_from_cmip6_metadata
+    }
+
+    simulation_table_paths = Path(DATA_DOCS_REPO).glob(
+        "docs/source/*/*/simulation_data/simulation_table.rst"
+    )
+    for simulation_table_page in simulation_table_paths:
+        variants_in_this_table = collect_links_from_table(str(simulation_table_page))
+        for variant in variants_in_this_table:
+            match = lookup.get(variant._key())
+            if match is not None:
+                match.e3sm_data_docs_page = str(simulation_table_page)
+            else:
+                variants_not_in_cmip6_metadata.add(variant)
+
+    return variants_not_in_cmip6_metadata
+
+
+def find_variants_not_on_data_docs(variants_from_cmip6_metadata: Set[Variant]) -> Set[Variant]:
+    variants_not_on_data_docs: Set[Variant] = set()
+    for variant in variants_from_cmip6_metadata:
+        if variant.e3sm_data_docs_page == "":
+            variants_not_on_data_docs.add(variant)
+    return variants_not_on_data_docs
+
+
+def _sort_key(variant: Variant) -> Tuple[str, str, str, str, str]:
+    return (
+        variant.institution_id,
+        variant.source_id,
+        variant.activity_id,
+        variant.experiment_id,
+        variant.variant_label,
+    )
+
+
+# The E3SM Data Docs repo's `docs/source/**/*.rst` pages are built to
+# `docs/source/**/*.html` under this base URL, e.g.
+#   docs/source/v3/CoupledSystem/simulation_data/simulation_table.rst  ->
+#   https://docs.e3sm.org/e3sm_data_docs/_build/html/v3/CoupledSystem/simulation_data/simulation_table.html
+DATA_DOCS_BASE_URL = "https://docs.e3sm.org/e3sm_data_docs/_build/html"
+DOCS_SOURCE_MARKER = "docs/source/"
+
+
+def _data_docs_relative_path(page_path: str) -> Optional[str]:
+    """e.g. '.../docs/source/v3/CoupledSystem/.../simulation_table.rst' ->
+    'v3/CoupledSystem/.../simulation_table.rst'"""
+    idx = page_path.find(DOCS_SOURCE_MARKER)
+    if idx == -1:
+        return None
+    return page_path[idx + len(DOCS_SOURCE_MARKER) :]
+
+
+def _data_docs_url(page_path: str) -> Optional[str]:
+    relative = _data_docs_relative_path(page_path)
+    if relative is None:
+        return None
+    relative_html = re.sub(r"\.rst$", ".html", relative)
+    return f"{DATA_DOCS_BASE_URL}/{relative_html}"
+
+
+def _data_docs_version_label(page_path: str) -> Optional[str]:
+    """e.g. 'v3/CoupledSystem/.../simulation_table.rst' -> 'v3'"""
+    relative = _data_docs_relative_path(page_path)
+    if relative is None:
+        return None
+    return relative.split("/")[0]
+
+
+def _make_markdown_table(title: str, variants: Set[Variant]) -> str:
+    lines = [
+        f"### {title}",
+        "",
+        "| Institution ID | Source ID | Activity ID | Experiment ID | Variant Label | Can be found on... |",
+        "|---|---|---|---|---|---|",
+    ]
+    for v in sorted(variants, key=_sort_key):
+        page_link = ""
+        if v.e3sm_data_docs_page:
+            url = _data_docs_url(v.e3sm_data_docs_page)
+            version = _data_docs_version_label(v.e3sm_data_docs_page)
+            if url and version:
+                page_link = f"[{version}]({url})"
+        lines.append(
+            f"| {v.institution_id} | {v.source_id} | {v.activity_id} | "
+            f"{v.experiment_id} | {v.variant_label} | {page_link} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    variants_from_cmip6_metadata: Set[Variant] = find_all_variants_from_cmip6_metadata()
+
+    variants_not_in_cmip6_metadata: Set[Variant] = process_links_in_data_docs(
+        variants_from_cmip6_metadata
+    )
+    variants_not_on_data_docs: Set[Variant] = find_variants_not_on_data_docs(
+        variants_from_cmip6_metadata
+    )
+    variants_on_both: Set[Variant] = variants_from_cmip6_metadata - variants_not_on_data_docs
+
+    report = "\n".join(
+        [
+            _make_markdown_table(
+                "Variants on CMIP6 Metadata, but not on E3SM Data Docs",
+                variants_not_on_data_docs,
+            ),
+            _make_markdown_table(
+                "Variants not on CMIP6 Metadata, but on E3SM Data Docs",
+                variants_not_in_cmip6_metadata,
+            ),
+            _make_markdown_table(
+                "Variants on both CMIP6 Metadata and E3SM Data Docs",
+                variants_on_both,
+            ),
+        ]
+    )
+    output_path = Path("metadata_review.md")
+    output_path.write_text(report)
+    print(f"Wrote report to {output_path.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/metadata_reviewer.py
+++ b/utils/metadata_reviewer.py
@@ -45,6 +45,7 @@ class Variant(object):
         experiment_id: str = "",
         variant_label: str = "",
         e3sm_data_docs_page: str = "",
+        e3sm_data_docs_link: str = "",
     ):
         self.institution_id: str = institution_id
         self.source_id: str = source_id
@@ -52,6 +53,7 @@ class Variant(object):
         self.experiment_id: str = experiment_id
         self.variant_label: str = variant_label
         self.e3sm_data_docs_page: str = e3sm_data_docs_page
+        self.e3sm_data_docs_link: str = e3sm_data_docs_link
 
     def _key(self) -> Tuple[str, str, str]:
         # institution_id / activity_id are deliberately excluded from the
@@ -242,6 +244,13 @@ def collect_links_from_table(rst_path: str) -> List[Variant]:
             continue
 
         source_id, experiment_id, variant_label = parsed
+
+        simulation_name = row[0] if row else ""
+        url = _data_docs_url(rst_path)
+        e3sm_data_docs_link = (
+            f"[{simulation_name}]({url})" if simulation_name and url else ""
+        )
+
         variants.append(
             Variant(
                 institution_id=UNKNOWN,
@@ -250,6 +259,7 @@ def collect_links_from_table(rst_path: str) -> List[Variant]:
                 experiment_id=experiment_id,
                 variant_label=variant_label,
                 e3sm_data_docs_page=rst_path,
+                e3sm_data_docs_link=e3sm_data_docs_link,
             )
         )
 
@@ -273,7 +283,8 @@ def process_links_in_data_docs(variants_from_cmip6_metadata: Set[Variant]) -> Se
         for variant in variants_in_this_table:
             match = lookup.get(variant._key())
             if match is not None:
-                match.e3sm_data_docs_page = str(simulation_table_page)
+                match.e3sm_data_docs_page = variant.e3sm_data_docs_page
+                match.e3sm_data_docs_link = variant.e3sm_data_docs_link
             else:
                 variants_not_in_cmip6_metadata.add(variant)
 
@@ -323,14 +334,6 @@ def _data_docs_url(page_path: str) -> Optional[str]:
     return f"{DATA_DOCS_BASE_URL}/{relative_html}"
 
 
-def _data_docs_version_label(page_path: str) -> Optional[str]:
-    """e.g. 'v3/CoupledSystem/.../simulation_table.rst' -> 'v3'"""
-    relative = _data_docs_relative_path(page_path)
-    if relative is None:
-        return None
-    return relative.split("/")[0]
-
-
 def _make_markdown_table(title: str, variants: Set[Variant]) -> str:
     lines = [
         f"### {title}",
@@ -339,15 +342,9 @@ def _make_markdown_table(title: str, variants: Set[Variant]) -> str:
         "|---|---|---|---|---|---|",
     ]
     for v in sorted(variants, key=_sort_key):
-        page_link = ""
-        if v.e3sm_data_docs_page:
-            url = _data_docs_url(v.e3sm_data_docs_page)
-            version = _data_docs_version_label(v.e3sm_data_docs_page)
-            if url and version:
-                page_link = f"[{version}]({url})"
         lines.append(
             f"| {v.institution_id} | {v.source_id} | {v.activity_id} | "
-            f"{v.experiment_id} | {v.variant_label} | {page_link} |"
+            f"{v.experiment_id} | {v.variant_label} | {v.e3sm_data_docs_link} |"
         )
     lines.append("")
     return "\n".join(lines)

--- a/utils/metadata_reviewer.py
+++ b/utils/metadata_reviewer.py
@@ -20,6 +20,15 @@ a URL-encoded JSON blob in an `activeFacets` parameter). They do not encode
 (source_id, experiment_id, variant_label). When a variant is discovered only
 from a data-docs link (i.e. it has no corresponding CMIP6-Metadata JSON),
 its institution_id/activity_id fields are set to "N/A" rather than guessed.
+
+NOTE on experiment_id casing:
+E3SM Data Docs and CMIP6-Metadata don't always agree on the casing of
+experiment_id (e.g. `piClim-histghg` vs `piClim-histGHG`). Matching therefore
+ignores case, but CMIP6-Metadata is treated as the source of truth: when a
+CMIP6-Metadata variant is matched to a data-docs link, the variant's
+displayed experiment_id keeps CMIP6-Metadata's original casing. Only
+variants found *exclusively* in data-docs (no CMIP6-Metadata counterpart)
+display data-docs' casing, since there's no CMIP6-Metadata value to prefer.
 """
 
 import json
@@ -57,8 +66,11 @@ class Variant(object):
 
     def _key(self) -> Tuple[str, str, str]:
         # institution_id / activity_id are deliberately excluded from the
-        # identity key -- see module docstring.
-        return (self.source_id, self.experiment_id, self.variant_label)
+        # identity key -- see module docstring. experiment_id is lower-cased
+        # for the purposes of matching/hashing/equality only -- the
+        # *displayed* experiment_id (self.experiment_id) keeps its original
+        # casing; see the module docstring's note on experiment_id casing.
+        return (self.source_id, self.experiment_id.lower(), self.variant_label)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Variant):
@@ -270,7 +282,11 @@ def process_links_in_data_docs(variants_from_cmip6_metadata: Set[Variant]) -> Se
     variants_not_in_cmip6_metadata: Set[Variant] = set()
 
     # Lookup by identity key so we can mutate the *actual* objects that live
-    # in `variants_from_cmip6_metadata` when we find a matching link.
+    # in `variants_from_cmip6_metadata` when we find a matching link. Since
+    # `_key()` lower-cases experiment_id, this matches regardless of casing
+    # differences between CMIP6-Metadata and data-docs, and because we only
+    # ever update e3sm_data_docs_page/e3sm_data_docs_link on `match` (never
+    # experiment_id itself), CMIP6-Metadata's original casing is preserved.
     lookup: Dict[Tuple[str, str, str], Variant] = {
         v._key(): v for v in variants_from_cmip6_metadata
     }
@@ -299,13 +315,43 @@ def find_variants_not_on_data_docs(variants_from_cmip6_metadata: Set[Variant]) -
     return variants_not_on_data_docs
 
 
-def _sort_key(variant: Variant) -> Tuple[str, str, str, str, str]:
+# Matches a variant_label's r/i/p/f indices, e.g. "r6i1p1f1" ->
+# ("6", "1", "1", "1"). Used only for sorting -- the variant_label string
+# itself is never rewritten/reformatted (e.g. never zero-padded).
+VARIANT_LABEL_INDICES_RE = re.compile(
+    r"^r(?P<r>\d+)i(?P<i>\d+)p(?P<p>\d+)f(?P<f>\d+)$"
+)
+
+
+def _variant_label_sort_key(variant_label: str) -> Tuple[int, int, int, int]:
+    """Sort key for a variant_label that orders r/i/p/f as integers (so
+    r6i1p1f1 sorts before r25i1p1f1), instead of lexicographically as
+    strings (which would put r25... before r6...).
+
+    Falls back to a key of all -1s (sorting before any real index) for
+    labels that don't match the expected "rXiYpZfW" pattern, so malformed
+    labels don't crash the sort.
+    """
+    match = VARIANT_LABEL_INDICES_RE.match(variant_label)
+    if not match:
+        return (-1, -1, -1, -1)
+    return (
+        int(match.group("r")),
+        int(match.group("i")),
+        int(match.group("p")),
+        int(match.group("f")),
+    )
+
+
+def _sort_key(
+    variant: Variant,
+) -> Tuple[str, str, str, str, Tuple[int, int, int, int]]:
     return (
         variant.institution_id,
         variant.source_id,
         variant.activity_id,
         variant.experiment_id,
-        variant.variant_label,
+        _variant_label_sort_key(variant.variant_label),
     )
 
 


### PR DESCRIPTION
Add metadata reviewer script and resulting report. This is a follow-up to #81 (make sure `e3sm_data_docs` includes everything that was on e3sm.org) & #85 (make sure `e3sm_data_docs` includes everything that is on ESGF MetaGrid).

Claude-generated PR summary:

---

## Add `metadata_reviewer.py` to cross-check E3SM Data Docs against CMIP6 Metadata

### Summary

Adds a new utility script, `utils/metadata_reviewer.py`, that cross-checks the variants described in the [CMIP6-Metadata](https://github.com/E3SM-Project/CMIP6-Metadata) repo against the ESGF links published in E3SM Data Docs' `simulation_table.rst` pages. This makes it possible to catch cases where E3SM data is registered on ESGF/CMIP6-Metadata but hasn't yet been documented in `e3sm_data_docs`.

### What it does

Running `python metadata_reviewer.py` from `utils/` generates `utils/metadata_review.md`, containing three tables:

1. **Variants on CMIP6 Metadata, but not on E3SM Data Docs** — these should be added to the docs as soon as possible.
2. **Variants not on CMIP6 Metadata, but on E3SM Data Docs** — expected to be rare; would indicate CMIP6 Metadata is stale relative to ESGF.
3. **Variants on both** — no action needed, included for completeness/auditing.

This PR includes a generated `utils/metadata_review.md` showing the current state: a number of E3SM-1-0, E3SM-1-1, E3SM-1-1-ECA, and E3SM-3-0 variants are present in CMIP6-Metadata but missing from the docs, while everything else lines up.

### Implementation notes

- **Matching key**: Variants are identified by `(source_id, experiment_id, variant_label)` only. ESGF search links embedded in the data-docs tables don't encode `institution_id` or `activity_id`, so those fields can't be used for matching; when a variant is discovered only from a data-docs link, they're reported as `N/A`.
- **Case-insensitive experiment_id matching**: `experiment_id` casing sometimes differs between the two sources (e.g. `piClim-histghg` vs `piClim-histGHG`). Matching is case-insensitive, but CMIP6-Metadata casing is treated as authoritative for display; data-docs casing is only shown for variants with no CMIP6-Metadata counterpart.
- **variant_label derivation**: Read from the CMIP6-Metadata JSON filename (`<experiment_id>_<variant_label>.json`), cross-checked against the realization/initialization/physics/forcing index fields when present, with a warning (not a hard failure) on mismatch.
- **ESGF link parsing**: Supports both plain query-parameter links and links encoding facets as a URL-encoded JSON blob (`activeFacets`).
- **Table parsing**: Parses Sphinx `.. list-table::` blocks generically by locating the "ESGF Links" column via the header row, rather than assuming a fixed column position.
- **Sorting**: Variant labels are sorted numerically by their r/i/p/f indices (so `r6i1p1f1` sorts before `r25i1p1f1`) rather than lexicographically.

### Configuration

Two module-level constants at the top of the script need to be set to local paths before running:
```python
CMIP6_METADATA_REPO = "/home/ac.forsyth2/ez/CMIP6-Metadata"
DATA_DOCS_REPO = "/home/ac.forsyth2/ez/e3sm_data_docs/"
```

### Docs

`utils/README.md` is updated with a new "Checking for missing data" section explaining how to run the script and interpret its output.